### PR TITLE
Add support for Linux: chrome and firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 # node-browser-history
 
 This module will gather browser history from common internet browsers. Given a time frame.
-> Operating Systems Supported
+
+## Supported operating systems
 
 * Windows
 * Mac
+* Linux (only Firefox and Chrome)
 
-> Browsers Supported
+## Supported browsers
 
 ![Chrome](https://i.imgur.com/SgiX8bb.png)
 ![Maxthon](https://i.imgur.com/D2rD9CV.png)
-![FireFox](https://i.imgur.com/Xy4ZZTT.png)
+![Firefox](https://i.imgur.com/Xy4ZZTT.png)
 ![Opera](https://i.imgur.com/VVYCBQW.png)
 ![SeaMonkey](https://i.imgur.com/OgTBYE8.png)
 ![Torch](https://i.imgur.com/9xB5ReO.png)
@@ -19,15 +21,19 @@ This module will gather browser history from common internet browsers. Given a t
 ![Microsoft Edge](https://i.imgur.com/Iyd33UT.png)
 ![Avast Browser](https://i.imgur.com/gIY5cjx.png)
 
-* Google Chrome
-* Maxthon (Mac Only)
-* Microsoft Edge
-* Mozilla Firefox
-* Opera
-* Seamonkey
-* Torch (Windows Only)
-* Vivaldi (Mac Only)
-* Brave
+| Browser         | Windows | Mac | Linux |
+| --------------- | ------- | --- | ----- |
+| Google Chrome   | ✅      | ✅  | ✅    |
+| Maxthon         | -       | ✅  | -     |
+| Microsoft Edge  | ✅      | ✅  | -     |
+| Mozilla Firefox | ✅      | ✅  | ✅    |
+| Opera           | ✅      | ✅  | -     |
+| Seamonkey       | ✅      | ✅  | -     |
+| Torch           | ✅      | -   | -     |
+| Vivaldi         | -       | ✅  | -     |
+| Brave           | ✅      | ✅  | -     |
+| Avast Browser   | ✅      | ✅  | -     |
+
 
 # How to Install
 

--- a/browsers.js
+++ b/browsers.js
@@ -1,5 +1,6 @@
 const Path =  require('path')
 const fs = require("fs");
+const { setupDefaultPaths: setupPaths } = require('./history_paths');
 
 const CHROME = "Google Chrome",
     FIREFOX = "Mozilla Firefox",
@@ -41,33 +42,7 @@ let defaultPaths = {
     avast: ""
 };
 
-if (process.platform !== "darwin") {
-
-    let basePath = Path.join(process.env.HOMEDRIVE, "Users", process.env.USERNAME, "AppData");
-
-    defaultPaths.chrome = Path.join(basePath, "Local", "Google", "Chrome");
-    defaultPaths.avast = Path.join(basePath, "Local", "Google", "AVAST Software");
-    defaultPaths.firefox = Path.join(basePath, "Roaming", "Mozilla", "Firefox");
-    defaultPaths.opera = Path.join(basePath, "Roaming", "Opera Software");
-    defaultPaths.edge = Path.join(basePath, "Local", "Microsoft", "Edge");
-    defaultPaths.torch = Path.join(basePath, "Local", "Torch", "User Data");
-    defaultPaths.seamonkey = Path.join(basePath, "Roaming", "Mozilla", "SeaMonkey");
-    defaultPaths.brave = Path.join(basePath, "Local", "BraveSoftware");
-
-} else {
-    let homeDirectory = process.env.HOME;
-
-    defaultPaths.chrome = Path.join(homeDirectory, "Library", "Application Support", "Google", "Chrome");
-    defaultPaths.avast = Path.join(homeDirectory, "Library", "Application Support", "AVAST Software", "Browser");
-    defaultPaths.firefox = Path.join(homeDirectory, "Library", "Application Support", "Firefox");
-    defaultPaths.edge = Path.join(homeDirectory, "Library", "Application Support", "Microsoft Edge");
-    // defaultPaths.safari = Path.join(homeDirectory, "Library", "Safari");
-    defaultPaths.opera = Path.join(homeDirectory, "Library", "Application Support", "com.operasoftware.Opera");
-    defaultPaths.maxthon = Path.join(homeDirectory, "Library", "Application Support", "com.maxthon.mac.Maxthon");
-    defaultPaths.vivaldi = Path.join(homeDirectory, "Library", "Application Support", "Vivaldi");
-    defaultPaths.seamonkey = Path.join(homeDirectory, "Library", "Application Support", "SeaMonkey", "Profiles");
-    defaultPaths.brave = Path.join(homeDirectory, "Library", "Application Support", "BraveSoftware", "Brave-Browser");
-}
+setupPaths(defaultPaths);
 
 /**
  * Find all files recursively in specific folder with specific extension, e.g:
@@ -92,7 +67,7 @@ function findFilesInDir(startPath, filter, targetFile, depth = 0) {
         let filename = Path.join(startPath, files[i]);
         if (!fs.existsSync(filename)) {
             // console.log('file doesn\'t exist ', startPath);
-            return results;
+            continue;
         }
         let stat = fs.lstatSync(filename);
         if (stat.isDirectory()) {
@@ -125,7 +100,6 @@ function findPaths(path, browserName) {
     switch (browserName) {
         case FIREFOX:
         case SEAMONKEY:
-
             return findFilesInDir(path, ".sqlite", Path.sep + 'places.sqlite');
         case CHROME:
         case TORCH:

--- a/history_paths.js
+++ b/history_paths.js
@@ -1,0 +1,51 @@
+const Path = require('path');
+
+const homeDirectory = process.env.HOME;
+
+function setupForWindows(defaultPaths) {
+    const appDataDirectory = Path.join(process.env.HOMEDRIVE, "Users", process.env.USERNAME, "AppData");
+    
+    defaultPaths.chrome = Path.join(appDataDirectory, "Local", "Google", "Chrome");
+    defaultPaths.avast = Path.join(appDataDirectory, "Local", "Google", "AVAST Software");
+    defaultPaths.firefox = Path.join(appDataDirectory, "Roaming", "Mozilla", "Firefox");
+    defaultPaths.opera = Path.join(appDataDirectory, "Roaming", "Opera Software");
+    defaultPaths.edge = Path.join(appDataDirectory, "Local", "Microsoft", "Edge");
+    defaultPaths.torch = Path.join(appDataDirectory, "Local", "Torch", "User Data");
+    defaultPaths.seamonkey = Path.join(appDataDirectory, "Roaming", "Mozilla", "SeaMonkey");
+    defaultPaths.brave = Path.join(appDataDirectory, "Local", "BraveSoftware");
+}
+
+function setupForMac(defaultPaths) {
+    defaultPaths.chrome = Path.join(homeDirectory, "Library", "Application Support", "Google", "Chrome");
+    defaultPaths.avast = Path.join(homeDirectory, "Library", "Application Support", "AVAST Software", "Browser");
+    defaultPaths.firefox = Path.join(homeDirectory, "Library", "Application Support", "Firefox");
+    defaultPaths.edge = Path.join(homeDirectory, "Library", "Application Support", "Microsoft Edge");
+    // defaultPaths.safari = Path.join(homeDirectory, "Library", "Safari");
+    defaultPaths.opera = Path.join(homeDirectory, "Library", "Application Support", "com.operasoftware.Opera");
+    defaultPaths.maxthon = Path.join(homeDirectory, "Library", "Application Support", "com.maxthon.mac.Maxthon");
+    defaultPaths.vivaldi = Path.join(homeDirectory, "Library", "Application Support", "Vivaldi");
+    defaultPaths.seamonkey = Path.join(homeDirectory, "Library", "Application Support", "SeaMonkey", "Profiles");
+    defaultPaths.brave = Path.join(homeDirectory, "Library", "Application Support", "BraveSoftware", "Brave-Browser");
+}
+
+function setupForLinux(defaultPaths) {
+    defaultPaths.firefox = Path.join(homeDirectory, ".mozilla", "firefox");
+    defaultPaths.chrome = Path.join(homeDirectory, ".config", "google-chrome", "Default");
+}
+
+function setupDefaultPaths(defaultPaths) {
+    switch (process.platform) {
+        case 'darwin':
+            return setupForMac(defaultPaths);
+        case 'linux':
+            return setupForLinux(defaultPaths);
+        case 'win32':
+            return setupForWindows(defaultPaths);
+        default:
+            console.error(`Platform ${process.platform} is not supported by node-browser-history`);
+    }
+}
+
+module.exports = {
+    setupDefaultPaths
+};

--- a/index.js
+++ b/index.js
@@ -4,7 +4,15 @@ const Database = require("sqlite-async");
 const uuidV4 = require("uuid").v4;
 
 const browsers = require("./browsers");
+const { tmpdir } = require("os");
 
+/**
+ * Get the path to the temp directory of
+ * the current platform.
+ */
+function getTempDir() {
+    return process.env.TMP || process.env.TMPDIR || tmpdir();
+}
 
 /**
  * Runs the the proper function for the given browser. Some browsers follow the same standards as
@@ -55,7 +63,7 @@ async function getHistoryFromDb(newDbPath, sql, browserName) {
 }
 
 function copyDbAndWalFile(dbPath, fileExtension = 'sqlite') {
-    const newDbPath = path.join(process.env.TMP ? process.env.TMP : process.env.TMPDIR, uuidV4() + `.${fileExtension}`);
+    const newDbPath = path.join(getTempDir(), uuidV4() + `.${fileExtension}`);
     const filePaths = {};
     filePaths.db = newDbPath;
     filePaths.dbWal = `${newDbPath}-wal`;
@@ -87,7 +95,7 @@ async function getChromeBasedBrowserRecords(paths, browserName, historyTimeLengt
     let newDbPaths = [];
     let browserHistory = [];
     for (let i = 0; i < paths.length; i++) {
-        let newDbPath = path.join(process.env.TMP ? process.env.TMP : process.env.TMPDIR, uuidV4() + ".sqlite");
+        let newDbPath = path.join(getTempDir(), uuidV4() + ".sqlite");
         newDbPaths.push(newDbPath);
         let sql = `SELECT title, datetime(last_visit_time/1000000 + (strftime('%s', '1601-01-01')),'unixepoch') last_visit_time, url from urls WHERE DATETIME (last_visit_time/1000000 + (strftime('%s', '1601-01-01')), 'unixepoch')  >= DATETIME('now', '-${historyTimeLength} minutes') group by title, last_visit_time order by last_visit_time`;
         //Assuming the sqlite file is locked so lets make a copy of it


### PR DESCRIPTION
This adds base support for Linux, so the dependency no longer causes an error when imported. It also adds support for Firefox and Chrome history on Linux.

Closes #15 

## Example

### Chrome

```js
> BrowserHistory.getChromeHistory().then(console.log)
[
  [
    {
      title: 'Twitter. It’s what’s happening / Twitter',
      utc_time: '2021-08-06 20:56:31',
      url: 'https://twitter.com/',
      browser: 'Google Chrome'
    }
  ]
]
```

### Firefox

```js
> BrowserHistory.getFirefoxHistory().then(console.log)
[
  [
    {
      title: null,
      utc_time: '2021-08-06 20:53:26',
      url: 'https://github.com/KevSlashNull/node-browser-history/compare/15-Add-support-for-linux-chrome-and-firefox?expand=1',
      browser: 'Mozilla Firefox'
    },
    {
      title: null,
      utc_time: '2021-08-06 20:53:27',
      url: 'https://github.com/MyOutDeskLLC/node-browser-history/compare/master...KevSlashNull:15-Add-support-for-linux-chrome-and-firefox?expand=1',
      browser: 'Mozilla Firefox'
    }
  ],
  []
]
```

The empty array (second item) is because I have installed both Firefox and Firefox Developer Edition.